### PR TITLE
[HZN-2841] PART 1 - Reworked Dockerfile to be able to publish to Avinor owned DockerHub and ghcr.io

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,53 +3,52 @@ on:
     branches:
       - master
     tags:
-      - '*'
+      - "*"
   pull_request: {}
 name: Build and Publish
+
+env:
+  TAG: ${{ github.ref_name }}
+  IS_RELEASE: ${{ startsWith(github.ref, 'refs/tags') }} # Another way to get event of Release (because github.event_name = 'push' and not 'release'). Seems to be GitHub Actions bug.
+  USE_DOCKERHUB: false
+  USE_GHCR: true
+  testStr: "event_name: ${{ github.event_name }} | ref: ${{ github.ref }} | ref_name: ${{ github.ref_name }}"
+
 jobs:
   build_and_publish:
     name: Build and Publish
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
-    - name: '[Dockerhub] Docker login'
-      uses: actions/docker/login@master
-      env:
-        DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-        DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-    - name: '[Github] Docker login'
-      uses: actions/docker/login@master
-      env:
-        DOCKER_PASSWORD: '${{ secrets.GH_DOCKER_PASSWORD }}'
-        DOCKER_USERNAME: $GITHUB_ACTOR
-        DOCKER_REGISTRY_URL: docker.pkg.github.com
-    - name: Build Image
-      uses: actions/docker/cli@master
-      with:
-        args: build -t kube-nginx-proxy .
-    - name: '[Dockerhub] Tag Image'
-      uses: actions/docker/tag@master
-      if: github.ref == 'refs/heads/master' || github.event_name == 'release'
-      with:
-        args: --env kube-nginx-proxy kylemcc/kube-nginx-proxy
-    - name: '[Github] Tag Image'
-      uses: actions/docker/tag@master
-      if: github.ref == 'refs/heads/master' || github.event_name == 'release'
-      with:
-        args: --env kube-nginx-proxy docker.pkg.github.com/kylemcc/kube-nginx-proxy/kube-nginx-proxy
-    - name: '[Dockerhub] Push Image'
-      uses: actions/docker/cli@master
-      if: github.ref == 'refs/heads/master' || github.event_name == 'release'
-      with:
-        args: push kylemcc/kube-nginx-proxy
-    - name: '[Github] Push Image'
-      uses: actions/docker/cli@master
-      if: github.ref == 'refs/heads/master' || github.event_name == 'release'
-      with:
-        args: push docker.pkg.github.com/kylemcc/kube-nginx-proxy/kube-nginx-proxy
-    - name: Send Slack Notification
-      uses: kylemcc/actions/slack-webhook@master
-      if: always() && (github.ref == 'refs/heads/master' || github.event_name == 'release')
-      env:
-        SLACK_MESSAGE: '$GITHUB_REPOSITORY: Build ${{ job.status }}'
-        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      - uses: actions/checkout@master
+      - run: echo "${{ env.testStr }}"
+
+      - name: "[Dockerhub] Docker login"
+        if: ${{ env.USE_DOCKERHUB && env.IS_RELEASE == 'true' }}  
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}  
+      
+      - name: "[GHCR] Docker login"
+        if: ${{ env.USE_GHCR && env.IS_RELEASE == 'true' }} 
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io # docker.pkg.github.com
+          username: ${{ github.actor }} # ${{ github.repository_owner }}
+          password: ${{ github.token }} # ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Set up Docker Buildx
+        if: ${{ env.IS_RELEASE == 'true' }} 
+        uses: docker/setup-buildx-action@v1
+      
+      - name: Build and push
+        if: ${{ env.IS_RELEASE == 'true' }} 
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          # platforms: linux/amd64,linux/arm64 # by default linux.amd64
+          push: ${{ env.IS_RELEASE == 'true' }} 
+          tags: | 
+            ghcr.io/${{ github.repository_owner }}/kube-nginx-proxy:${{ env.TAG }}
+            ghcr.io/${{ github.repository_owner }}/kube-nginx-proxy:latest
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,15 @@
-FROM nginx:1.14.2
-LABEL maintainer="Kyle McCullough <kylemcc@gmail.com>"
+# In scope of task HZN-2866 change at least to FROM nginx:1.16.1 to be the same as in Horizon Frontend, BUT ONLY after verifcation of NGINX API changes between those versions.
+# And later try :latest or :1.22.0 or :1.23.0 => http://nginx.org/en/download.html
+FROM nginx:1.14.2 
 
-LABEL version="0.2.2"
+LABEL maintainer="Andrii Lundiak <andrii.lundiak@soprasteria.com>"
+
+# 0.2.x were `kylemcc` last versions | DockerHub: kylemcc
+# 0.3.x were `khaliqgant` versions | DockerHub: khaliqgant
+# 0.4.x may be `andrii-lundiak` (GitHub) | DockerHub: andriilundiak
+# 0.5.x may be assumed `avinor-ps` (GitHub) | DockerHub: avinorps or avinor
+LABEL version="0.4.6"
+
 
 # Install available package updates, wget, and install/updates certificates
 RUN apt-get update \
@@ -16,17 +24,21 @@ RUN echo "daemon off;" >> /etc/nginx/nginx.conf \
   && sed -i 's/^http {/&\n    server_names_hash_bucket_size 128;/g' /etc/nginx/nginx.conf \
   && rm -f /etc/nginx/conf.d/default.conf
 
-# install forego, kube-gen, and kubectl
+# install kubectl, forego and kube-gen
 ENV KUBE_GEN_VERSION 0.3.0
+
 ADD https://storage.googleapis.com/kubernetes-release/release/v1.8.15/bin/linux/amd64/kubectl /usr/local/bin/
-RUN wget https://bin.equinox.io/c/ekMN3bCZFUn/forego-stable-linux-amd64.tgz \
-  && tar -C /usr/local/bin -xzvf forego-stable-linux-amd64.tgz \
-  && rm forego-stable-linux-amd64.tgz \
-  && wget https://github.com/kylemcc/kube-gen/releases/download/$KUBE_GEN_VERSION/kube-gen-linux-amd64-$KUBE_GEN_VERSION.tar.gz \
+RUN chmod +x /usr/local/bin/kubectl
+
+# https://github.com/ddollar/forego/issues/127#issuecomment-1235315871
+RUN wget https://github.com/jpillora/forego/releases/download/v1.0.4/forego_1.0.4_linux_amd64.gz \
+  && gzip -d -N forego_1.0.4_linux_amd64.gz \
+  && mv forego /usr/local/bin \ 
+  && chmod +x /usr/local/bin/forego
+
+RUN wget https://github.com/kylemcc/kube-gen/releases/download/$KUBE_GEN_VERSION/kube-gen-linux-amd64-$KUBE_GEN_VERSION.tar.gz \
   && tar -C /usr/local/bin -xvzf kube-gen-linux-amd64-$KUBE_GEN_VERSION.tar.gz \
   && rm kube-gen-linux-amd64-$KUBE_GEN_VERSION.tar.gz \
-  && chmod +x /usr/local/bin/forego \
-  && chmod +x /usr/local/bin/kubectl \
   && chmod +x /usr/local/bin/kube-gen
 
 COPY . /app/

--- a/README.md
+++ b/README.md
@@ -1,12 +1,53 @@
 # kube-nginx-proxy (Avinor overrides)
 
+## GitHub info
 
 Originally, repo was forked from [Kyle McCullough](https://github.com/kylemcc/kube-nginx-proxy) by Khaliq Gant to his [profile](https://github.com/khaliqgant/kube-nginx-proxy). And Khaliq made relevant code changes for using within Avinor. Now, Avinor as `avinor-ps` organization did a fork from Khaliq's version, and will continue to use it. Ideally, if Kyle merge [PR in his repo](https://github.com/kylemcc/kube-nginx-proxy/pull/6) (created by Khailq in 2020), then we can avoid using this fork and switch to original package from initial author.
 
-Khaliq did somehow deploy/publish fresh Docker images to GitHub Docker registry under his name - https://hub.docker.com/r/khaliqgant/kube-nginx-proxy/tags - latest `0.3.1` is used now in Avinor Horizon project. But under the hood, Docker image itself still depends on `kylemcc` packages `kube-gen`, `kube-nginx-proxy` and one public package `forego`.
 
-GitHub Actions `publish.yml` fails for org. `avinor-ps` and may not even executed because of payment issue. But we may need it in future.
+GitHub Actions `publish.yml` fails for org. `avinor-ps` and may not be even executed because of payment issue. But we may need it in future.
 
+GitHub Container Registry packages can be seen here: https://github.com/avinor-ps/kube-nginx-proxy/pkgs/container/kube-nginx-proxy
+
+
+## DockerHub info
+Kyle's Dockerhub - https://hub.docker.com/r/kylemcc/kube-nginx-proxy
+
+Khaliq did somehow deploy/publish fresh Docker images to GitHub Docker registry under his name - https://hub.docker.com/r/khaliqgant/kube-nginx-proxy/tags - latest `0.3.1` is used now in Avinor Horizon project. But under the hood, Docker image itself still depends on `kylemcc` package `kube-nginx-proxy` and his another `kube-gen@0.3.0` (last build in 2018) and one public package `forego@dev` (which is now NOT available from Equinox - [details](https://github.com/ddollar/forego/issues/127#issuecomment-1235245982) but there seems to be `jpillora` user's re-released latest version `1.0.4` (Dec-2021) - [details](https://github.com/jpillora/forego/releases)).
+
+
+There are two Avinor-related DockerHub accounts:
+- https://hub.docker.com/u/avinor since Apr-2016
+- https://hub.docker.com/u/avinorps since Sep-2017
+
+But we don't have password to both.
+
+## Build/Test/Usage info
+
+So far all depends on `nginx@1.14.2`.
+
+To test locally if `Dockerfile` works OK, run command: `docker build .` but it will create Docker image with same name - `nginx`. So you better run: `docker build -t kube-nginx-proxy .` which will create image `kube-nginx-proxy:latest`.
+
+To test if Docker image can be fetched from [DockerHub](https://hub.docker.com/) run 
+
+```sh
+docker pull {DOCKERHUB_USER}/kube-nginx-proxy:latest
+```
+or 
+```
+docker pull {DOCKERHUB_USER}/kube-nginx-proxy:{EXACT_VERSION}
+``` 
+
+To test if Docker image can be fetched from [GitHub Container Registry](https://github.com/orgs/avinor-ps/packages?repo_name=kube-nginx-proxy) run 
+
+```
+docker pull ghcr.io/{GITHUB_USER}/kube-nginx-proxy:latest
+``` 
+or 
+
+```
+docker pull ghcr.io/{GITHUB_USER}/kube-nginx-proxy:{EXACT_VERSION}
+``` 
 
 # kube-nginx-proxy
 ![latest 0.1.3](https://img.shields.io/badge/latest-0.1.3-green.svg?style=flat)

--- a/kube-nginx-proxy-daemonset.yaml
+++ b/kube-nginx-proxy-daemonset.yaml
@@ -4,7 +4,7 @@ metadata:
   name: "kube-nginx-proxy"
   labels:
     app: "kube-nginx-proxy"
-    version: "0.1.3"
+    version: "0.4.5"
   namespace: "dev"
   annotations:
     description: "nginx reverse proxy for services and pods powered by annotations"
@@ -22,7 +22,10 @@ spec:
       #  <label_name>: <label_value>
       containers:
         - name: "kube-nginx-proxy"
-          image: "kylemcc/kube-nginx-proxy:0.1.3"
+          # I was able to publish to my DockerHub account, because I don't have password to neither `avinor` nor `avinorps` accounts`
+          # This line means, that during Wildcard deployment exactly this version of package will be taken.
+          # In future here should be either: `avinorps/kube-nginx-proxy:latest` or `avinor/kube-nginx-proxy:latest` or `ghcr.io/avinor=ps/kube-nginx-proxy:latest`
+          image: "andriilundiak/kube-nginx-proxy:0.4.5"
           resources:
             requests:
               cpu: "100m"


### PR DESCRIPTION
PART 1 (need to update `master` branch with valid, according to proper GitHub Actions API, to be able later rely on Build and Publish to **DockerHub** and **GitHub Container Registry**)

`Dockerfile` changes
- Fixed 404 URL to `forego` package, which is failing when `docker build .` or Publish on GitHub Actions.

`github/workflows/publish.yml` changes:
- Changed `kylemcc` to refer to `avinor-ps` for proper distribution on DockerHub.
- Removed code from `Dockerfile` which refers to original author Slack integration, which we DO NOT want, when we release Avinor owned image to DockerHub.


PS1.  This PR bring proper code for publish to DockerHub. But it requires GitHub repo owner to setup `Secrets`: `DOCKER_USERNAME` and `DOCKER_ACCESS_TOKEN` (can be actual password, but both works as password). 
![image](https://user-images.githubusercontent.com/85486996/190199167-6bcc7efc-1abf-4daf-8437-b7eb1d7955c2.png)

And maybe `SLACK_WEBHOOK_URL` if Slack integration needed.

PS2. But, we don't know passwords to login to either of these DockerHub accounts:

- https://hub.docker.com/u/avinor since Apr-2016
- https://hub.docker.com/u/avinorps since Sep-2017

As result so far, we can ONLY try publishing to `ghcr.io`. 

But there is also some error - `403 Forbidden` at the end of publish and I don't know why.

**EXPERIMENTAL package** is created, but it's `Private`:
![image](https://user-images.githubusercontent.com/85486996/190208450-3bdf84af-257c-41b0-9dbd-03ea06df095b.png)

![image](https://user-images.githubusercontent.com/85486996/190208999-93260d7b-f5bf-4c9f-9b37-029fd70b0d4c.png)




